### PR TITLE
Fixed things related to the bonus point increase for first time correct answer

### DIFF
--- a/app/Http/Controllers/ExamSessionController.php
+++ b/app/Http/Controllers/ExamSessionController.php
@@ -267,9 +267,11 @@ class ExamSessionController extends Controller
         $result = ($correct == $correctAnswersCount) ? 1 : 0;
 
         $userQuestion = DB::table('user_question')->where('user_id', auth()->user()->id)->where('question_id', $question->id)->first();
+        $previousScore = null;
         
         if ($recordAnswer) {
             $updatedScore = 0;
+            $previousScore = $userQuestion->score;
             if ($result == 1) {
                 if ($userQuestion->score == 0) {
                     $updatedScore = config('test.min_score') + config('test.add_score');
@@ -346,6 +348,7 @@ class ExamSessionController extends Controller
             'examSet' => $examSet,
             'session' => $session,
             'userQuestionStats' => $userQuestion,
+            'previousScore' => $previousScore,
         ]);
 
         return view('exam-session.answer');

--- a/app/Http/Controllers/ExamSessionController.php
+++ b/app/Http/Controllers/ExamSessionController.php
@@ -495,7 +495,8 @@ class ExamSessionController extends Controller
         $updateMastery = array();
 
         // See if the current score equals a threshold
-        if (($updatedScore == config('test.grade_apprentice')) && ($originalScore == (config('test.grade_apprentice') - 1))) {
+        // Also, if the original score was below the minimum then they could have gotten a bonus point this time around
+        if ((($updatedScore == config('test.grade_apprentice')) || $updatedScore == config('test.grade_apprentice') +1) && ($originalScore == (config('test.grade_apprentice') - 1))) {
             $updateMastery['mastery_apprentice_change'] = $session->mastery_apprentice_change + 1;
 
         } else if (($updatedScore == (config('test.grade_apprentice') - 1)) && ($originalScore == config('test.grade_apprentice'))) {
@@ -515,7 +516,6 @@ class ExamSessionController extends Controller
         } else if (($updatedScore == (config('test.grade_proficient') - 1)) && ($originalScore == config('test.grade_proficient'))) {
             $updateMastery['mastery_proficient_change'] = $session->mastery_proficient_change - 1;
         }
-
 
         if (($updatedScore == config('test.grade_mastered')) && ($originalScore == (config('test.grade_mastered') - 1))) {
             $updateMastery['mastery_mastered_change'] = $session->mastery_mastered_change + 1;

--- a/resources/views/exam-session/answer.blade.php
+++ b/resources/views/exam-session/answer.blade.php
@@ -55,10 +55,10 @@
                     <li>
                         @if ($i == $userQuestionStats->score)
                             <div class="timeline-start">
-                                @if ($correct)
-                                    <div class="badge badge-secondary">Mastery: + {{ config('test.add_score') }}</div>
+                                @if ($userQuestionStats->score > $previousScore)
+                                    <div class="badge badge-secondary">Mastery: + {{ $userQuestionStats->score - $previousScore }}</div>
                                 @else
-                                    <div class="badge badge-secondary">Mastery: - {{ config('test.sub_score') }}</div>
+                                    <div class="badge badge-secondary">Mastery: - {{ $previousScore - $userQuestionStats->score }}</div>
                                 @endif
                             </div>
                         @endif


### PR DESCRIPTION
If a person has never seen the question before, but they get it wrong, they still are awarded one point to bring them to the minimum (apprentice means that you have just seen the question).

The person shouldn't get the same mastery score no matter if they got the question right or wrong, so if they get it right and this is their first time seeing the question then they should get a bonus point, because they would have gotten one point no matter what.